### PR TITLE
8 thematic breaks section breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,37 @@ src += 'ipsum';
 console.log(md.render(src));
 ```
 
+## Explicit Section Close
+### Usage
+```js
+var md = require('markdown-it')();
+md.use(require('markdown-it-header-sections'),{
+  explicitCloseEnabled: true
+});
+
+var src = '# first header\n';
+src += 'lorem\n\n'
+src += '___\n\n'  //this will close the existing section
+src += '## second header\n';
+src += 'ipsum';
+
+console.log(md.render(src));
+
+```
+
+### Options
+| option                   | default    | effect                                     |
+|--------------------------|------------|--------------------------------------------|
+| `explicitCloseEnabled`   | ` false`   | controls if explictClose is enabled or not |
+| ` .closeOneMarkDown`     | `'___'`    | markdown trigger -> close current section  |
+| ` .closeAllMarkDown`     | `'______'` | markdown trigger -> close all sections     |
+| ` .addAnanMarkDown`      | `'---'`    | markdown trigger -> add anonymous section  |
+| ` .splitSectionMarkDown` | `'***'`    | markdown trigger -> split current section  |
+
+> [!NOTE]
+> * horizontal rule entries not within a section will still be rendered as `<hr>`
+> * horizontal rule entries that don't match exactly one of the triggers will still be rendered as `<hr>`
+
 [demo as jsfiddle](https://jsfiddle.net/arve0/5dn54cow/1/)
 
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = function headerSections(md) {
 
     for (var i = 0, l = state.tokens.length; i < l; i++) {
       var token = state.tokens[i];
+      let keepToken = true;
 
       // record level of nesting
       if (token.type.search('heading') !== 0) {
@@ -67,8 +68,58 @@ module.exports = function headerSections(md) {
         }
         sections.push(section);
       }
-
-      tokens.push(token);
+      else
+      {
+        if (token.type === 'hr') {
+          const lastSection = last(sections);
+          switch(token.markup){
+            case '___': //3x_
+              //close current section
+              if (last(sections)) {
+                keepToken = false;
+                closeSections(section);
+              }
+              break;
+            case '______': //6x_
+              //close all sections
+              if (last(sections)) {
+                keepToken = false;
+                closeAllSections();
+              }
+              break;
+            case '---': //3x-
+              //anon section
+              keepToken = false;
+              let lastHeader = 0;
+              if (lastSection){
+                lastHeader = lastSection.header;
+              }
+              var newSection = {
+                header: headingLevel(`h${lastHeader}`),
+                nesting: nestedLevel
+              };
+              tokens.push(openSection([]));
+              sections.push(newSection);
+              break;
+            case '***': //3x*
+              //split section
+              if (lastSection) {
+                keepToken = false;
+                closeSections(section);
+                var newSection = {
+                  header: headingLevel(`h${lastSection.header}`),
+                  nesting: nestedLevel
+                };
+                tokens.push(openSection([]));
+                sections.push(newSection);
+              }
+              break;
+          }
+        }
+      
+      }
+      if (keepToken)
+        tokens.push(token);
     }  // end for every token
     closeAllSections();
 

--- a/test.js
+++ b/test.js
@@ -202,4 +202,115 @@ describe('markdown-it-header-sections', function(){
     var res = md.render(src);
     assert.equal(res, expected);
   });
+
+
+  /* new section closing */
+  it('sectionClose: should not close section when not enabled', function(){
+    var src = multiline.stripIndent(function(){/*
+      # asdf {#asdf}
+
+      ---
+      qwerty
+    */});
+    var expected = multiline.stripIndent(function(){/*
+      <section id="asdf">
+      <h1>asdf</h1>
+      <hr>
+      <p>qwerty</p>
+      </section>
+
+    */});
+    md.use(require('markdown-it-attrs'));
+    md.use(headerSections);
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('sectionClose: should close section when enabled: close current', function(){
+    var src = multiline.stripIndent(function(){/*
+      # asdf {#asdf}
+
+      ___
+      qwerty
+    */});
+    var expected = multiline.stripIndent(function(){/*
+      <section id="asdf">
+      <h1>asdf</h1>
+      </section>
+      <p>qwerty</p>
+
+    */});
+    md.use(require('markdown-it-attrs'));
+    md.use(headerSections, {explicitCloseEnabled:true});
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('sectionClose: should close sections when enabled: close all', function(){
+    var src = multiline.stripIndent(function(){/*
+      # asdf {#asdf}
+      ## ghjk
+
+      ______
+      qwerty
+    */});
+    var expected = multiline.stripIndent(function(){/*
+      <section id="asdf">
+      <h1>asdf</h1>
+      <section>
+      <h2>ghjk</h2>
+      </section>
+      </section>
+      <p>qwerty</p>
+
+    */});
+    md.use(require('markdown-it-attrs'));
+    md.use(headerSections, {explicitCloseEnabled:true});
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('sectionClose: should split section when enabled', function(){
+    var src = multiline.stripIndent(function(){/*
+      # asdf {#asdf}
+
+      ***
+      qwerty
+    */});
+    var expected = multiline.stripIndent(function(){/*
+      <section id="asdf">
+      <h1>asdf</h1>
+      </section>
+      <section>
+      <p>qwerty</p>
+      </section>
+
+    */});
+    md.use(require('markdown-it-attrs'));
+    md.use(headerSections, {explicitCloseEnabled:true});
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
+
+  it('sectionClose: should insert section when enabled', function(){
+    var src = multiline.stripIndent(function(){/*
+      # asdf {#asdf}
+
+      ---
+      qwerty
+    */});
+    var expected = multiline.stripIndent(function(){/*
+      <section id="asdf">
+      <h1>asdf</h1>
+      <section>
+      <p>qwerty</p>
+      </section>
+      </section>
+
+    */});
+    md.use(require('markdown-it-attrs'));
+    md.use(headerSections, {explicitCloseEnabled:true});
+    var res = md.render(src);
+    assert.equal(res, expected);
+  });
 });


### PR DESCRIPTION
Adds functionality desired in https://github.com/arve0/markdown-it-header-sections/issues/8 

Specifically I used the conventions indicated by: https://github.com/arve0/markdown-it-header-sections/issues/8#issuecomment-363770889

The change is not enabled by default and must be enabled with a new option `explicitCloseEnabled` which must be set to true.

Additionally the specific forms of the hr markdown is customize-able to alter the specific trigger. Only restriction is that the markdown trigger must resolve to an `<hr>` element already.
